### PR TITLE
removes double !!

### DIFF
--- a/src/utils/handleHtmlProp.js
+++ b/src/utils/handleHtmlProp.js
@@ -1,5 +1,5 @@
 const hasHtml = (prop, arr) => (
-  !!(arr.filter((item) => item.property === prop)[0].html)
+  arr.filter((item) => item.property === prop)[0].html
 );
 
 const extractHtml = (prop, arr) => (


### PR DESCRIPTION
!!(arr.filter((item) => item.property === prop)[0].html)
this is far easier to read
arr.filter((item) => item.property === prop)[0].html
