### PR TITLE
Feature: Extend mui-data-table config object to add viewSearchBarOnload property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-data-table",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Data table for react material-ui",
   "repository": {
     "type": "git",

--- a/src/lib/mui-data-table.js
+++ b/src/lib/mui-data-table.js
@@ -70,7 +70,7 @@ export default class MuiDataTable extends React.Component {
 
     this.state = {
       disabled: true,
-      style: searchStyle,
+      style: viewSearchBarOnload ? {...searchStyle, opacity: 1} : searchStyle,
       idempotentData: props.config.data,
       paginatedIdempotentData: new Paginate(props.config.data),
       perPageSelection: props.config.paginated.rowsPerPage || 5,
@@ -78,7 +78,7 @@ export default class MuiDataTable extends React.Component {
       searchData: [],
       isSearching: false,
       navigationStyle,
-      iconStyleSearch : viewSearchBarOnload ? {...iconStyleSearch, opacity: 1} : iconStyleSearch
+      iconStyleSearch: iconStyleSearch
     };
 
     this.columns = injectProp(props.config.columns);

--- a/src/lib/mui-data-table.js
+++ b/src/lib/mui-data-table.js
@@ -60,6 +60,7 @@ export default class MuiDataTable extends React.Component {
     super();
     let tableData = props.config.data || [];
     let rowsPerPage = props.config.paginated.constructor === Object ? props.config.paginated.rowsPerPage : 5;
+    let viewSearchBarOnload  = props.config.viewSearchBarOnload || false;
 
     tableData = props.config.paginated ? new Paginate(tableData).perPage(rowsPerPage) : tableData;
 
@@ -77,7 +78,7 @@ export default class MuiDataTable extends React.Component {
       searchData: [],
       isSearching: false,
       navigationStyle,
-      iconStyleSearch
+      iconStyleSearch : viewSearchBarOnload ? {...iconStyleSearch, opacity: 1} : iconStyleSearch
     };
 
     this.columns = injectProp(props.config.columns);


### PR DESCRIPTION
#### Why is this needed?
Currently `mui-data-table`' `search-bar` is hidden by default. This feature now allows a user to choose whether or not they want the `search-bar` to be displayed by setting ` ` `viewSearchBarOnload` to `true` or `false` in the config object